### PR TITLE
Fix/history view layout

### DIFF
--- a/SitSmartDetection_SwiftUI/ContentView.swift
+++ b/SitSmartDetection_SwiftUI/ContentView.swift
@@ -78,5 +78,8 @@ struct MainView: View{
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         ContentView()
+            .environmentObject(AuthManager())
+            .environmentObject(UserInfoViewModel())
+            .environmentObject(HistoryViewModel(timeUnit: .year))
     }
 }

--- a/SitSmartDetection_SwiftUI/History/View/HistoryView.swift
+++ b/SitSmartDetection_SwiftUI/History/View/HistoryView.swift
@@ -262,5 +262,6 @@ struct HistoryView_Previews: PreviewProvider {
                     .datastoreLocation(.applicationDefault)
                 ])
             }
+            .environmentObject(HistoryViewModel(timeUnit: .year))
     }
 }

--- a/SitSmartDetection_SwiftUI/History/View/HistoryView.swift
+++ b/SitSmartDetection_SwiftUI/History/View/HistoryView.swift
@@ -80,7 +80,7 @@ struct HistoryView: View {
                 let height = geometry.size.height
                 Path { path in
                     path.move(to: CGPoint(x: 0, y: height * 0.9))  // 定义半圆的底部起点
-                    path.addCurve(to: CGPoint(x: width, y: height * 0.9), control1: CGPoint(x: width / 3, y: 275), control2: CGPoint(x: 2 * width / 3, y: 275))
+                    path.addCurve(to: CGPoint(x: width, y: height * 0.9), control1: CGPoint(x: width / 3, y: height * 0.75), control2: CGPoint(x: 2 * width / 3, y: height * 0.75))
                     path.addLine(to: CGPoint(x: width, y: height))
                     path.addLine(to: CGPoint(x: 0, y: height))
                 }
@@ -126,7 +126,6 @@ struct HistoryView: View {
             Text("\(historyVM.displayDate)")
                 .font(.title3)
                 .foregroundStyle(Color.white)
-                .frame(width: historyVM.currentTimeTextWidth)
             
             Button {
                 historyVM.touchAdd()

--- a/SitSmartDetection_SwiftUI/ViewModel/HistoryViewModel.swift
+++ b/SitSmartDetection_SwiftUI/ViewModel/HistoryViewModel.swift
@@ -17,7 +17,6 @@ class HistoryViewModel: ObservableObject {
     @Published var displayDate: String = ""
     @Published var addTime: Bool = false
     @Published var averageScore: Double = 0
-    @Published var currentTimeTextWidth: CGFloat = 60
     
     lazy var calendar: Calendar = {
         var cal = Calendar.current
@@ -136,16 +135,12 @@ class HistoryViewModel: ObservableObject {
         switch selectedTime {
         case 0:
             timeUnit = .year
-            currentTimeTextWidth = 50
         case 1:
             timeUnit = .month
-            currentTimeTextWidth = 150
         case 2:
             timeUnit = .weekOfMonth
-            currentTimeTextWidth = 210
         case 3:
             timeUnit = .day
-            currentTimeTextWidth = 180
         default:
             break
         }


### PR DESCRIPTION
1. Add environment object injection for Xcode preview
2. Remove currentTimeTextWidth to let the DisplayDate text dynamically render